### PR TITLE
fix wifi lib build issue On Celadon Q

### DIFF
--- a/lib/wifi_hal.cpp
+++ b/lib/wifi_hal.cpp
@@ -545,8 +545,9 @@ wifi_error wifi_set_bssid_hotlist(wifi_request_id id, wifi_interface_handle ifac
 }
 
 wifi_error wifi_start_sending_offloaded_packet(wifi_request_id id,
-		wifi_interface_handle iface, u8 *ip_packet, u16 ip_packet_len,
-		u8 *src_mac_addr, u8 *dst_mac_addr, u32 period_msec) {
+		wifi_interface_handle iface, u16 ether_type, u8 *ip_packet,
+		u16 ip_packet_len, u8 *src_mac_addr, u8 *dst_mac_addr,
+		u32 period_msec) {
 	return WIFI_ERROR_NOT_SUPPORTED;
 }
 


### PR DESCRIPTION
one API not match  wifi_start_sending_offloaded_packet

Tracked-On:
Signed-off-by: gao huadong <huadongx.gao@intel.com>
