### PR TITLE
Prevent compiler from optimizing out security checks for libwifihal-intel

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -13,6 +13,9 @@ LOCAL_CPPFLAGS += -Wno-unused-parameter -Wno-int-to-pointer-cast -Wno-missing-fi
 LOCAL_CPPFLAGS += \
         -D_FORTIFY_SOURCE=2 \
         -fstack-protector-strong \
+        -fno-strict-overflow \
+        -fno-delete-null-pointer-checks \
+        -fwrapv \
         -Wformat -Wformat-security \
         -Wall -Wextra -Wsign-compare -Wpointer-arith \
         -Wcast-qual -Wcast-align \

--- a/wpa_supplicant_8_lib/Android.mk
+++ b/wpa_supplicant_8_lib/Android.mk
@@ -44,6 +44,9 @@ endif
 ifdef CONFIG_ANDROID_LOG
 L_CFLAGS += -DCONFIG_ANDROID_LOG
 endif
+L_CFLAGS += -fno-strict-overflow \
+            -fno-delete-null-pointer-checks \
+            -fwrapv
 
 ########################
 


### PR DESCRIPTION
…ntel

Adding compiler flags to prevent optimization on security checks

Tracked-On: OAM-89291
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>