### PR TITLE
Prevent compiler from optimizing out security checks for libwifihal-intel

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -9,10 +9,11 @@ UTIL_DIR := util
 
 LOCAL_REQUIRED_MODULES :=
 
-LOCAL_CPPFLAGS += -Wno-unused-parameter -Wno-int-to-pointer-cast -Wno-missing-field-initializers
 LOCAL_CPPFLAGS += \
         -D_FORTIFY_SOURCE=2 \
         -fstack-protector-strong \
+        -fno-strict-overflow \
+        -fwrapv \
         -Wformat -Wformat-security \
         -Wall -Wextra -Wsign-compare -Wpointer-arith \
         -Wcast-qual -Wcast-align \

--- a/wpa_supplicant_8_lib/Android.mk
+++ b/wpa_supplicant_8_lib/Android.mk
@@ -44,6 +44,21 @@ endif
 ifdef CONFIG_ANDROID_LOG
 L_CFLAGS += -DCONFIG_ANDROID_LOG
 endif
+L_CFLAGS += \
+           -D_FORTIFY_SOURCE=2 \
+           -fstack-protector-strong \
+           -fno-strict-overflow \
+           -fwrapv \
+           -Wformat -Wformat-security \
+           -Wall -Wextra -Wsign-compare -Wpointer-arith \
+           -Wno-unused-parameter \
+           -Wno-unused-variable \
+           -Wno-unused-function \
+           -Wno-missing-field-initializers \
+           -Wno-int-to-pointer-cast \
+           -Wno-conversion-null \
+           -Werror \
+           -Wnull-dereference
 
 ########################
 


### PR DESCRIPTION
Prevent compiler from optimizing out security checks for libwifihal-intel

Adding compiler flags to prevent optimization on security checks

Tracked-On: OAM-89292
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>