### PR TITLE
Remove -fno-strict-overflow to fix Android T build errors

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -13,7 +13,6 @@ LOCAL_CPPFLAGS += -Wno-unused-parameter -Wno-int-to-pointer-cast -Wno-missing-fi
 LOCAL_CPPFLAGS += \
         -D_FORTIFY_SOURCE=2 \
         -fstack-protector-strong \
-        -fno-strict-overflow \
         -fno-delete-null-pointer-checks \
         -fwrapv \
         -Wformat -Wformat-security \

--- a/wpa_supplicant_8_lib/Android.mk
+++ b/wpa_supplicant_8_lib/Android.mk
@@ -44,8 +44,7 @@ endif
 ifdef CONFIG_ANDROID_LOG
 L_CFLAGS += -DCONFIG_ANDROID_LOG
 endif
-L_CFLAGS += -fno-strict-overflow \
-            -fno-delete-null-pointer-checks \
+L_CFLAGS += -fno-delete-null-pointer-checks \
             -fwrapv
 
 ########################


### PR DESCRIPTION
This is a WA patch to fix the below build error in
Android T:
clang: error: argument unused during compilation:
'-fno-strict-overflow' [-Werror,-Wunused-command-line-argument]

As per https://gcc.gnu.org/onlinedocs/gcc-4.9.1/gcc/Optimize-Options.html
"Using -fwrapv means that integer signed overflow is fully defined:
it wraps. When -fwrapv is used, there is no difference between
-fstrict-overflow and -fno-strict-overflow for integers. With
-fwrapv certain types of overflow are permitted. For example,
if the compiler gets an overflow when doing arithmetic on constants,
the overflowed value can still be used with -fwrapv, but not otherwise."

Tracked-On: OAM-103588
Signed-off-by: svenate <salini.venate@intel.com>