### PR TITLE
Remove some repeated log in Wifi hal

### DIFF
--- a/android.config
+++ b/android.config
@@ -1,3 +1,3 @@
 # Debug level: trace=0, debug=1, warning=2, error=3
-CONFIG_DEBUG=1
+CONFIG_DEBUG=3
 #CONFIG_LLS_ENABLED=y

--- a/defconfig
+++ b/defconfig
@@ -1,5 +1,5 @@
 # Debug level: trace=0, debug=1, warning=2, error=3
-CONFIG_DEBUG=1
+CONFIG_DEBUG=3
 #CONFIG_NO_SYSLOG is not set
 CONFIG_DEBUG_STDOUT=y
 #CONFIG_GLOBAL_CTRL_IFACE

--- a/lib/driver_if.cpp
+++ b/lib/driver_if.cpp
@@ -2044,13 +2044,13 @@ void driver_if_events(void *handle)
 	while (!drv->in_cleanup) {
 		pfd[1].fd = drv->nl_rtt ? nl_socket_get_fd(drv->nl_rtt) : -1;
 		int res = ppoll(pfd, NFDS, &ts, &sms);
-		hal_printf(MSG_ERROR, "Out of event poll");
+		hal_printf(MSG_DEBUG, "Out of event poll");
 
 		if (res < 0 && errno != EINTR) {
 			hal_printf(MSG_ERROR,
 				   "Error event socket res=%d, errno=%d", res, errno);
 		} else if (res == 0) {
-			hal_printf(MSG_ERROR, "Timeout on event socket");
+			hal_printf(MSG_DEBUG, "Timeout on event socket");
 		} else {
 			for (i = 0; i < NFDS; i++) {
 				if (pfd[i].revents & POLLERR) {


### PR DESCRIPTION
Change log level to error,
close below repeated debug log:
10-15 11:22:21.370   522  1348 E wifi hal: Out of event poll
10-15 11:22:21.370   522  1348 D wifi hal: Data on event socket 0
10-15 11:22:21.370   522  1348 D wifi hal: Drv Event 70 received

Tests:
above log disapeared

Tracked-On: OAM-126416