### PR TITLE
Adding Mutex Lock to Avoid Race Condition

### DIFF
--- a/lib/driver_if.cpp
+++ b/lib/driver_if.cpp
@@ -2041,8 +2041,10 @@ void driver_if_events(void *handle)
 		return;
 	}
 
+	MUTEX_LOCK(&drv->sync);
 	hal_printf(MSG_DEBUG, "Starting event loop tid=%u",
 		   drv->event_thread);
+	MUTEX_UNLOCK(&drv->sync);
 
 	while (! [&]()-> bool {
 			MUTEX_LOCK(&drv->sync);


### PR DESCRIPTION
The following fields encountered a race condition. Adding a `mutex_lock` in the critical section resolves the issue:
- `drv->event_thread`

Tests:
- Android boot up success
- WiFi/Hotspot ON/OFF success
- Connect WiFi to network success

Tracked-On: OAM-131040